### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/app/src/main/java/com/mounacheikhna/harrypotterbooks/MainActivity.java
+++ b/app/src/main/java/com/mounacheikhna/harrypotterbooks/MainActivity.java
@@ -47,6 +47,26 @@ public class MainActivity extends AppCompatActivity {
   private Interpolator mInterpolator;
   private ObjectAnimator mColorChange;
 
+  public static final Property<FrameLayout, Integer> FOREGROUND_COLOR =
+          new Animations.IntProperty<FrameLayout>("foregroundColor") {
+
+            @Override public void setValue(FrameLayout layout, int value) {
+              if (layout.getForeground() instanceof ColorDrawable) {
+                ((ColorDrawable) layout.getForeground().mutate()).setColor(value);
+              } else {
+                layout.setForeground(new ColorDrawable(value));
+              }
+            }
+
+            @Override public Integer get(FrameLayout layout) {
+              if (layout.getForeground() instanceof ColorDrawable) {
+                return ((ColorDrawable) layout.getForeground()).getColor();
+              } else {
+                return Color.TRANSPARENT;
+              }
+            }
+          };
+
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.main);
@@ -114,25 +134,5 @@ public class MainActivity extends AppCompatActivity {
     mColorChange.setEvaluator(new ArgbEvaluator());
     mColorChange.setInterpolator(mInterpolator);
   }
-
-  public static final Property<FrameLayout, Integer> FOREGROUND_COLOR =
-      new Animations.IntProperty<FrameLayout>("foregroundColor") {
-
-        @Override public void setValue(FrameLayout layout, int value) {
-          if (layout.getForeground() instanceof ColorDrawable) {
-            ((ColorDrawable) layout.getForeground().mutate()).setColor(value);
-          } else {
-            layout.setForeground(new ColorDrawable(value));
-          }
-        }
-
-        @Override public Integer get(FrameLayout layout) {
-          if (layout.getForeground() instanceof ColorDrawable) {
-            return ((ColorDrawable) layout.getForeground()).getColor();
-          } else {
-            return Color.TRANSPARENT;
-          }
-        }
-      };
 
 }

--- a/app/src/main/java/com/mounacheikhna/harrypotterbooks/api/harrypotter/model/Book.java
+++ b/app/src/main/java/com/mounacheikhna/harrypotterbooks/api/harrypotter/model/Book.java
@@ -14,6 +14,27 @@ public class Book implements Parcelable {
   private String cover;
   private int quantity;
 
+  public static final Creator<Book> CREATOR = new Creator<Book>() {
+    public Book createFromParcel(Parcel source) {
+      return new Book(source);
+    }
+
+    public Book[] newArray(int size) {
+      return new Book[size];
+    }
+  };
+
+  public Book() {
+  }
+
+  protected Book(Parcel in) {
+    this.isbn = in.readString();
+    this.title = in.readString();
+    this.price = in.readInt();
+    this.cover = in.readString();
+    this.quantity = in.readInt();
+  }
+
   public String getIsbn() {
     return isbn;
   }
@@ -38,9 +59,6 @@ public class Book implements Parcelable {
     this.quantity = quantity;
   }
 
-  public Book() {
-  }
-
   @Override public int describeContents() {
     return 0;
   }
@@ -53,21 +71,4 @@ public class Book implements Parcelable {
     dest.writeInt(this.quantity);
   }
 
-  protected Book(Parcel in) {
-    this.isbn = in.readString();
-    this.title = in.readString();
-    this.price = in.readInt();
-    this.cover = in.readString();
-    this.quantity = in.readInt();
-  }
-
-  public static final Creator<Book> CREATOR = new Creator<Book>() {
-    public Book createFromParcel(Parcel source) {
-      return new Book(source);
-    }
-
-    public Book[] newArray(int size) {
-      return new Book[size];
-    }
-  };
 }

--- a/app/src/main/java/com/mounacheikhna/harrypotterbooks/util/Colors.java
+++ b/app/src/main/java/com/mounacheikhna/harrypotterbooks/util/Colors.java
@@ -12,12 +12,12 @@ import java.lang.annotation.RetentionPolicy;
 
 public class Colors {
 
-  private Colors() {
-  }
-
   public static final int IS_LIGHT = 0;
   public static final int IS_DARK = 1;
   public static final int LIGHTNESS_UNKNOWN = 2;
+
+  private Colors() {
+  }
 
   /**
    * Checks if the most populous color in the given palette is dark


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed
