### PR TITLE
General code quality fix-1

### DIFF
--- a/app/src/main/java/com/mounacheikhna/harrypotterbooks/data/prefs/GsonPreferenceAdapter.java
+++ b/app/src/main/java/com/mounacheikhna/harrypotterbooks/data/prefs/GsonPreferenceAdapter.java
@@ -39,12 +39,13 @@ public class GsonPreferenceAdapter<T> implements Preference.Adapter<T> {
       switch (this.syntaxExceptionBehavior) {
         case NULL:
           return null;
-        default:
-          throw new IllegalStateException("Unknown behavior: " + this.syntaxExceptionBehavior);
         case DELETE:
           delete(key, preferences);
+          break;
         case THROWN:
           throw jsonSyntaxException;
+        default:
+          throw new IllegalStateException("Unknown behavior: " + this.syntaxExceptionBehavior);
       }
     }
   }

--- a/app/src/main/java/com/mounacheikhna/harrypotterbooks/util/PriceFormatter.java
+++ b/app/src/main/java/com/mounacheikhna/harrypotterbooks/util/PriceFormatter.java
@@ -7,6 +7,8 @@ import android.annotation.SuppressLint;
  */
 public class PriceFormatter {
 
+  private PriceFormatter() {}
+
   @SuppressLint("DefaultLocale") public static String formatPrice(float price) {
     return String.format("%.2f", price);
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
